### PR TITLE
Fix: Use crmAssociationId for CRM ID mapping

### DIFF
--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -156,10 +156,11 @@ class BatchSink(ApiSink, HotglueBatchSink):
         data = response.get("data", {})
         results = data.get("results", [])
 
-        # Build lookup map: lookupKey -> externalId from input records
+        # Build lookup map: lookupKey -> crmAssociationId from input records
+        # crmAssociationId is the external CRM ID (e.g., Salesforce/HubSpot record ID)
         lookup_field = self._get_lookup_field()
         external_id_by_lookup = {
-            record.get(lookup_field): record.get("externalId")
+            record.get(lookup_field): record.get("crmAssociationId")
             for record in raw_records
             if record.get(lookup_field)
         }
@@ -171,7 +172,7 @@ class BatchSink(ApiSink, HotglueBatchSink):
             state = {
                 "success": result.get("success"),
                 "id": result.get("id"),
-                "externalId": external_id,
+                "crmAssociationId": external_id,
                 "lookupKey": lookup_key,
             }
 


### PR DESCRIPTION
## Summary

Fixes the external ID mapping in batch response handling.

**Issue:** The ETL script (`hubspot/etl.py:323`) outputs CRM external IDs in the `crmAssociationId` field:
```python
stream_data = stream_data.rename(columns={"remote_id": "crmAssociationId"})
```

But the target was looking for `externalId` which doesn't exist in the records.

**Fix:** Updated `handle_batch_response` to use `crmAssociationId` field for the lookup mapping.

## Test plan

- [ ] Re-deploy to dev environment
- [ ] Verify crmAssociationId <-> internal id mapping works correctly
- [ ] Check state output includes correct crmAssociationId values

🤖 Generated with [Claude Code](https://claude.com/claude-code)