### PR TITLE
Fix: Update target name to target-cbx1

### DIFF
--- a/target_api/target.py
+++ b/target_api/target.py
@@ -17,7 +17,7 @@ from target_hotglue.target_base import update_state
 class TargetApi(TargetHotglue):
     """Sample target for Api."""
 
-    name = "target-api"
+    name = "target-cbx1"
     SINK_TYPES = [RecordSink, BatchSink]
     target_counter = {}
 


### PR DESCRIPTION
## Summary

Updates target name from `target-api` to `target-cbx1` for better log readability.

**Before:** `name=target-api`
**After:** `name=target-cbx1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)