### PR TITLE
Fix: Output externalId in state for HotGlue UI

### DIFF
--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -172,7 +172,7 @@ class BatchSink(ApiSink, HotglueBatchSink):
             state = {
                 "success": result.get("success"),
                 "id": result.get("id"),
-                "crmAssociationId": external_id,
+                "externalId": external_id,  # HotGlue UI expects 'externalId' for mapping display
                 "lookupKey": lookup_key,
             }
 


### PR DESCRIPTION
## Summary

HotGlue UI expects `externalId` field in state for the "External ID" column display.

**Before:** State outputs `crmAssociationId` → UI shows `-`
**After:** State outputs `externalId` → UI shows the CRM record ID

The input field mapping remains unchanged (reads from `crmAssociationId` in records).

🤖 Generated with [Claude Code](https://claude.com/claude-code)