### PR TITLE
Enable externalId mapping for RecordSink

### DIFF
--- a/target_api/client.py
+++ b/target_api/client.py
@@ -41,6 +41,15 @@ class ApiSink(HotglueBaseSink):
     def bulk_endpoint(self) -> str:
         return f"api/t/v1/targets/{self.name}/bulk"
 
+    def _get_lookup_field(self) -> str:
+        """Return the lookup field based on stream name."""
+        stream_lower = self.stream_name.lower()
+        if "account" in stream_lower:
+            return "domain"
+        elif "contact" in stream_lower:
+            return "email"
+        return "id"
+
     @property
     def unified_schema(self) -> BaseModel:
         return None


### PR DESCRIPTION
## Summary

Enables the same `externalId` mapping for `RecordSink` (single record processing) that works in `BatchSink`.

**Changes:**
- Move `_get_lookup_field` to `ApiSink` base class for reuse by both sinks
- Update `RecordSink.upsert_record` to include `externalId` and `lookupKey` in state
- Remove duplicate `_get_lookup_field` from `BatchSink`

## Test plan

- [ ] Test with `process_as_batch: false` config
- [ ] Verify externalId shows in HotGlue UI for single record processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)