### PR TITLE
Release: Bulk batch response handling with externalId mapping

### DIFF
--- a/target_api/client.py
+++ b/target_api/client.py
@@ -38,6 +38,10 @@ class ApiSink(HotglueBaseSink):
         return f"api/t/v1/targets/{self.name}/upsert"
 
     @property
+    def bulk_endpoint(self) -> str:
+        return f"api/t/v1/targets/{self.name}/bulk"
+
+    @property
     def unified_schema(self) -> BaseModel:
         return None
 

--- a/target_api/client.py
+++ b/target_api/client.py
@@ -41,6 +41,15 @@ class ApiSink(HotglueBaseSink):
     def bulk_endpoint(self) -> str:
         return f"api/t/v1/targets/{self.name}/bulk"
 
+    def _get_lookup_field(self) -> str:
+        """Return the lookup field based on stream name."""
+        stream_lower = self.stream_name.lower()
+        if "account" in stream_lower:
+            return "domain"
+        elif "contact" in stream_lower:
+            return "email"
+        return "id"
+
     @property
     def unified_schema(self) -> BaseModel:
         return None

--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -172,7 +172,7 @@ class BatchSink(ApiSink, HotglueBatchSink):
             state = {
                 "success": result.get("success"),
                 "id": result.get("id"),
-                "crmAssociationId": external_id,
+                "externalId": external_id,  # HotGlue UI expects 'externalId' for mapping display
                 "lookupKey": lookup_key,
             }
 

--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -145,7 +145,7 @@ class BatchSink(ApiSink, HotglueBatchSink):
         Parse bulk upsert response and build state payloads.
 
         Args:
-            response: Bulk upsert API response with results array
+            response: Bulk upsert API response with data.results array
             raw_records: Original input records (for externalId lookup)
             batch_external_id: Optional batch ID for tracking
 
@@ -153,7 +153,8 @@ class BatchSink(ApiSink, HotglueBatchSink):
             dict with state_updates list containing per-record states
         """
         state_updates = []
-        results = response.get("results", [])
+        data = response.get("data", {})
+        results = data.get("results", [])
 
         # Build lookup map: lookupKey -> externalId from input records
         lookup_field = self._get_lookup_field()
@@ -185,8 +186,8 @@ class BatchSink(ApiSink, HotglueBatchSink):
         return {
             "state_updates": state_updates,
             "summary": {
-                "totalProcessed": response.get("totalProcessed"),
-                "successful": response.get("successful"),
-                "failed": response.get("failed"),
+                "totalProcessed": data.get("totalProcessed"),
+                "successful": data.get("successful"),
+                "failed": data.get("failed"),
             }
         }

--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -72,19 +72,21 @@ class BatchSink(ApiSink, HotglueBatchSink):
         return record
 
     def make_batch_request(self, records: List[dict]):
-        self.logger.info(f"Making request: {self.stream_name}")
+        """
+        Post batch of records to bulk endpoint and return response.
+
+        Returns:
+            dict: Full API response with results array for per-record handling
+        """
+        self.logger.info(f"Making bulk request: {self.stream_name} with {len(records)} records")
         response = self.request_api(
-            self._config.get("method", "POST").upper(), request_data=records, headers=self.custom_headers, verify=False
+            "POST",
+            endpoint=self.bulk_endpoint,
+            request_data=records,
+            headers=self.custom_headers,
+            verify=False
         )
-
-        id = None
-
-        try:
-            id = response.json().get("id")
-        except Exception as e:
-            self.logger.warning(f"Unable to get response's id: {e}")
-
-        return id
+        return response.json()
     
     def generate_batch_id(self):
         index = math.ceil(self._total_records_read/self.max_size)
@@ -100,30 +102,91 @@ class BatchSink(ApiSink, HotglueBatchSink):
         batch_external_id = None
 
         for i in range(0, len(raw_records), self.max_size):
-            records = raw_records[i:i+self.max_size]
+            batch_records = raw_records[i:i+self.max_size]
+            processed_records = batch_records
 
             if not self.send_empty_record:
-                records = list(map(lambda e: self.process_batch_record(e[1], e[0]), enumerate(records)))
+                processed_records = list(map(lambda e: self.process_batch_record(e[1], e[0]), enumerate(batch_records)))
 
                 inject_batch_ids = self.config.get("inject_batch_ids", False)
                 if inject_batch_ids:
                     batch_external_id = self.generate_batch_id()
-                    # add batch_external_id to each record
-                    [record.update({"hgBatchId": batch_external_id}) for record in records]
+                    [record.update({"hgBatchId": batch_external_id}) for record in processed_records]
 
             try:
-                id = self.make_batch_request(records)
-                result = self.handle_batch_response(id, batch_external_id)
-                for state in result.get("state_updates", list()):
+                response = self.make_batch_request(processed_records)
+                result = self.handle_batch_response(response, batch_records, batch_external_id)
+
+                for state in result.get("state_updates", []):
                     self.update_state(state)
+
+                summary = result.get("summary", {})
+                self.logger.info(
+                    f"Batch complete: {summary.get('successful', 0)}/{summary.get('totalProcessed', 0)} succeeded"
+                )
             except Exception as e:
-                state = {"error": str(e)}
-                if inject_batch_ids:
-                    state.update({"hgBatchId": batch_external_id})
+                self.logger.error(f"Batch request failed: {e}")
+                state = {"error": str(e), "batch_failed": True}
+                if batch_external_id:
+                    state["hgBatchId"] = batch_external_id
                 self.update_state(state)
                 
-    def handle_batch_response(self, id, batch_external_id=None) -> dict:
-        state = {"id": id, "success": True}
-        if batch_external_id:
-            state.update({"hgBatchId": batch_external_id})
-        return {"state_updates": [state]}
+    def _get_lookup_field(self) -> str:
+        """Return the lookup field based on stream name."""
+        stream_lower = self.stream_name.lower()
+        if "account" in stream_lower:
+            return "domain"
+        elif "contact" in stream_lower:
+            return "email"
+        return "id"
+
+    def handle_batch_response(self, response: dict, raw_records: List[dict], batch_external_id=None) -> dict:
+        """
+        Parse bulk upsert response and build state payloads.
+
+        Args:
+            response: Bulk upsert API response with results array
+            raw_records: Original input records (for externalId lookup)
+            batch_external_id: Optional batch ID for tracking
+
+        Returns:
+            dict with state_updates list containing per-record states
+        """
+        state_updates = []
+        results = response.get("results", [])
+
+        # Build lookup map: lookupKey -> externalId from input records
+        lookup_field = self._get_lookup_field()
+        external_id_by_lookup = {
+            record.get(lookup_field): record.get("externalId")
+            for record in raw_records
+            if record.get(lookup_field)
+        }
+
+        for result in results:
+            lookup_key = result.get("lookupKey")
+            external_id = external_id_by_lookup.get(lookup_key)
+
+            state = {
+                "success": result.get("success"),
+                "id": result.get("id"),
+                "externalId": external_id,
+                "lookupKey": lookup_key,
+            }
+
+            if batch_external_id:
+                state["hgBatchId"] = batch_external_id
+
+            if not result.get("success"):
+                state["error"] = result.get("error")
+
+            state_updates.append(state)
+
+        return {
+            "state_updates": state_updates,
+            "summary": {
+                "totalProcessed": response.get("totalProcessed"),
+                "successful": response.get("successful"),
+                "failed": response.get("failed"),
+            }
+        }

--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -156,10 +156,11 @@ class BatchSink(ApiSink, HotglueBatchSink):
         data = response.get("data", {})
         results = data.get("results", [])
 
-        # Build lookup map: lookupKey -> externalId from input records
+        # Build lookup map: lookupKey -> crmAssociationId from input records
+        # crmAssociationId is the external CRM ID (e.g., Salesforce/HubSpot record ID)
         lookup_field = self._get_lookup_field()
         external_id_by_lookup = {
-            record.get(lookup_field): record.get("externalId")
+            record.get(lookup_field): record.get("crmAssociationId")
             for record in raw_records
             if record.get(lookup_field)
         }
@@ -171,7 +172,7 @@ class BatchSink(ApiSink, HotglueBatchSink):
             state = {
                 "success": result.get("success"),
                 "id": result.get("id"),
-                "externalId": external_id,
+                "crmAssociationId": external_id,
                 "lookupKey": lookup_key,
             }
 

--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -51,10 +51,10 @@ class BatchSink(ApiSink, HotglueBatchSink):
     @property
     def max_size(self):
         if self.config.get("process_as_batch"):
-            batch_size = self.config.get("batch_size", 100)
+            batch_size = self.config.get("batch_size", 20)
             if batch_size:
                 return int(batch_size)
-        return 100
+        return 20
 
     def process_batch_record(self, record: dict, index: int) -> dict:
         if self.config.get("add_stream_key"):

--- a/target_api/target.py
+++ b/target_api/target.py
@@ -44,7 +44,7 @@ class TargetApi(TargetHotglue):
         self._sinks_active = OrderedDict()
 
     def get_sink_class(self, stream_name: str) -> Type[Sink]:
-        if self.config.get("process_as_batch"):
+        if self.config.get("process_as_batch", True):
             return BatchSink
         return RecordSink
 

--- a/target_api/target.py
+++ b/target_api/target.py
@@ -17,7 +17,7 @@ from target_hotglue.target_base import update_state
 class TargetApi(TargetHotglue):
     """Sample target for Api."""
 
-    name = "target-api"
+    name = "target-cbx1"
     SINK_TYPES = [RecordSink, BatchSink]
     target_counter = {}
 


### PR DESCRIPTION
## Summary

Release to production with bulk batch response handling and externalId mapping support.

**Changes included:**
- CB-8016: Bulk batch response handling for per-record state tracking
- Use `crmAssociationId` from input records for external ID mapping
- Output `externalId` in state for HotGlue UI display
- Default `process_as_batch` to `true` with batch size of 20
- Update target name to `target-cbx1` for better log readability
- Enable externalId mapping for RecordSink (single record processing)

**PRs included:**
- #5 - CB-8016: Implement bulk batch response handling
- #6 - Fix: Use crmAssociationId for CRM ID mapping
- #7 - Fix: Update target name to target-cbx1
- #8 - Fix: Output externalId in state for HotGlue UI
- #9 - Enable externalId mapping for RecordSink

🤖 Generated with [Claude Code](https://claude.com/claude-code)