### PR TITLE
CB-8875: Fix RecordSink response parsing for GenericResponse envelope

### DIFF
--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -49,10 +49,12 @@ class RecordSink(ApiSink, HotglueSink):
             verify=False
         )
 
-        # Parse new response format
+        # Parse GenericResponse<RecordIngestionResponse> format
+        # Response structure: {"status": {...}, "data": {"results": [...]}}
         id = None
         try:
-            results = response.json().get("results", [])
+            data = response.json().get("data", {})
+            results = data.get("results", [])
             if results:
                 result = results[0]
                 if result.get("status") == "SUCCESS":


### PR DESCRIPTION
## Summary
- Fixed `RecordSink.upsert_record()` response parsing to unwrap the `GenericResponse<RecordIngestionResponse>` envelope
- Previously, `response.json().get("results", [])` always returned `[]` because `results` is nested under `data`, so `entityId` was never extracted — causing "Upsert succeeded but no ID returned"
- `BatchSink.handle_batch_response()` was already parsing correctly; this aligns `RecordSink` to the same pattern

## Test plan
- [ ] Deploy and trigger a Marketo sync with `process_as_batch: false` to verify RecordSink correctly extracts entityId
- [ ] Verify snapshot contains entity IDs after ETL completes
- [ ] Confirm batch mode (default) continues to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)