### PR TITLE
CB-9826: Upgrade deprecated GitHub Actions for Node.js 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions to Node.js 24 compatible versions ahead of June 2, 2026 deprecation deadline
- `actions/checkout` v3 → v6
- `actions/setup-python` v4 → v5

## Test plan
- [ ] Verify test workflow passes