### PR TITLE
Fix drain_all crash when _latest_state is None

### DIFF
--- a/target_api/target.py
+++ b/target_api/target.py
@@ -98,7 +98,7 @@ class TargetApi(TargetHotglue):
                           is called after the target instance has finished
                           listening to the stdin
         """
-        state = copy.deepcopy(self._latest_state)
+        state = copy.deepcopy(self._latest_state) or {}
         self._drain_all(self._sinks_to_clear, 1)
         if is_endofpipe:
             for sink in self._sinks_to_clear:
@@ -117,8 +117,10 @@ class TargetApi(TargetHotglue):
             if s.name not in state.get("bookmarks", []):
                 state = update_state(state, s.latest_state, self.logger)
             else:
-                state["bookmarks"][s.name] = s.latest_state["bookmarks"][s.name]
-                state["summary"][s.name] = s.latest_state["summary"][s.name]
+                if isinstance(state.get("bookmarks"), dict):
+                    state["bookmarks"][s.name] = s.latest_state["bookmarks"][s.name]
+                if isinstance(state.get("summary"), dict):
+                    state["summary"][s.name] = s.latest_state["summary"][s.name]
         
         # for single record sinks drain_all is executed after processing the records therefore the latest_state is already populated
         # when there is no records drain_all is executed first so we process and write the state in drain_one and avoid writing an extra state here


### PR DESCRIPTION
## Summary

- Restore the `or {}` guard on the `_latest_state` snapshot in `drain_all` so an unpopulated state doesn't crash with `AttributeError: 'NoneType' object has no attribute 'get'`.
- Wrap the `bookmarks`/`summary` writes with `isinstance(..., dict)` checks, matching the upstream `target_hotglue.target_base.drain_all` (lines 423, 442–445).

## Background

Reported failure (HubSpot -> Different, accounts stream):

```
File ".../target_api/target.py", line 117, in drain_all
  if s.name not in state.get("bookmarks", []):
AttributeError: 'NoneType' object has no attribute 'get'
```

Contacts succeeded; accounts crashed. Root cause: when a `BatchSink` finishes without ever populating `self._latest_state` during `_process_record_message` (records queue, `sink.latest_state` stays `None` until `process_batch` runs inside `_drain_all`), the snapshot at line 101 was `None`, and `state.get(...)` blew up at line 117.

This override had diverged from the upstream `target_hotglue` base class, which has both guards. Restoring them keeps drift minimal.

## Test plan

- [ ] Re-run the failing HubSpot -> Different accounts sync; confirm a STATE message is emitted instead of an `AttributeError`.
- [ ] Run a contacts sync (the previously-working case) to confirm no regression.
- [ ] Investigate separately whether accounts is silently producing zero successful records (look at `Batch complete:` log lines from `target_api/sinks.py:161`) — the fix prevents the crash, but if `_latest_state` is staying `None` because every record is being skipped, that's an upstream data issue worth a follow-up.