### PR TITLE
Prod release: fix drain_all crash when _latest_state is None

### DIFF
--- a/target_api/target.py
+++ b/target_api/target.py
@@ -98,7 +98,7 @@ class TargetApi(TargetHotglue):
                           is called after the target instance has finished
                           listening to the stdin
         """
-        state = copy.deepcopy(self._latest_state)
+        state = copy.deepcopy(self._latest_state) or {}
         self._drain_all(self._sinks_to_clear, 1)
         if is_endofpipe:
             for sink in self._sinks_to_clear:
@@ -117,8 +117,10 @@ class TargetApi(TargetHotglue):
             if s.name not in state.get("bookmarks", []):
                 state = update_state(state, s.latest_state, self.logger)
             else:
-                state["bookmarks"][s.name] = s.latest_state["bookmarks"][s.name]
-                state["summary"][s.name] = s.latest_state["summary"][s.name]
+                if isinstance(state.get("bookmarks"), dict):
+                    state["bookmarks"][s.name] = s.latest_state["bookmarks"][s.name]
+                if isinstance(state.get("summary"), dict):
+                    state["summary"][s.name] = s.latest_state["summary"][s.name]
         
         # for single record sinks drain_all is executed after processing the records therefore the latest_state is already populated
         # when there is no records drain_all is executed first so we process and write the state in drain_one and avoid writing an extra state here


### PR DESCRIPTION
## Summary

Promote the drain_all None-state crash fix (#21) from `main` to `production`.

## Commits in this release

- b92f77b — Fix drain_all crash when _latest_state is None (#21)

## Background

HubSpot -> Different syncs were crashing on the accounts stream with:

```
File ".../target_api/target.py", line 117, in drain_all
  if s.name not in state.get("bookmarks", []):
AttributeError: 'NoneType' object has no attribute 'get'
```

The override of `drain_all` had dropped the `or {}` guard from upstream `target_hotglue.target_base.drain_all`, so a BatchSink that finished a run without ever populating `self._latest_state` would crash at end-of-pipe. #21 restored that guard plus the matching `isinstance(..., dict)` defenses around the `bookmarks`/`summary` writes.

## Test plan

- [ ] Re-run the failing HubSpot -> Different accounts sync against the production target build; confirm a STATE message is emitted instead of an AttributeError.
- [ ] Run a contacts sync to confirm no regression on the previously-working path.
- [ ] Spot-check `Batch complete: X/Y succeeded` log lines for the accounts stream to confirm records are flowing.