### PR TITLE
Drop non-UTF-8 fields before writing to CBX1

### DIFF
--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import json
-from typing import List
+import logging
+from typing import Any, List
 
 from target_hotglue.client import HotglueBatchSink, HotglueSink
 
@@ -12,9 +13,67 @@ import math
 import hashlib
 
 
+_DROP = object()
+
+
+def _scrub_utf8(value: Any, path: str, dropped: List[str]) -> Any:
+    """Recursively replace non-UTF-8 strings with the _DROP sentinel.
+
+    A string fails the check when it contains lone surrogates (e.g. data
+    decoded with errors='surrogateescape') and cannot be encoded as UTF-8.
+    Containers are kept; only the offending leaf is dropped.
+    """
+    if isinstance(value, str):
+        try:
+            value.encode("utf-8")
+        except UnicodeEncodeError:
+            dropped.append(path or "<root>")
+            return _DROP
+        return value
+    if isinstance(value, dict):
+        cleaned: dict = {}
+        for k, v in value.items():
+            child = f"{path}.{k}" if path else k
+            new_v = _scrub_utf8(v, child, dropped)
+            if new_v is _DROP:
+                continue
+            cleaned[k] = new_v
+        return cleaned
+    if isinstance(value, list):
+        cleaned_list: list = []
+        for i, v in enumerate(value):
+            child = f"{path}[{i}]"
+            new_v = _scrub_utf8(v, child, dropped)
+            if new_v is _DROP:
+                continue
+            cleaned_list.append(new_v)
+        return cleaned_list
+    return value
+
+
+def sanitize_record_utf8(
+    record: dict,
+    stream_name: str,
+    logger: logging.Logger,
+) -> dict:
+    """Drop fields whose string values are not valid UTF-8. Logs each drop."""
+    dropped: List[str] = []
+    cleaned = _scrub_utf8(record, "", dropped)
+    if dropped:
+        logger.warning(
+            "Dropped %d non-UTF-8 field(s) from %s record (sourceRecordId=%s): %s",
+            len(dropped),
+            stream_name,
+            record.get("sourceRecordId"),
+            ", ".join(dropped),
+        )
+    return cleaned
+
 
 class RecordSink(ApiSink, HotglueSink):
     def preprocess_record(self, record: dict, context: dict) -> dict:
+        record = sanitize_record_utf8(record, self.stream_name, self.logger)
+
         if self.config.get("add_stream_key"):
             record["stream"] = self.stream_name
 
@@ -84,9 +143,11 @@ class BatchSink(ApiSink, HotglueBatchSink):
         return 10
 
     def process_batch_record(self, record: dict, index: int) -> dict:
+        record = sanitize_record_utf8(record, self.stream_name, self.logger)
+
         if self.config.get("add_stream_key"):
             record["stream"] = self.stream_name
-            
+
         if self.config.get("metadata", None):
             metadata = record.get("metadata") or {}
 

--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -33,7 +33,15 @@ def _scrub_utf8(value: Any, path: str, dropped: List[str]) -> Any:
     if isinstance(value, dict):
         cleaned: dict = {}
         for k, v in value.items():
-            child = f"{path}.{k}" if path else k
+            if isinstance(k, str):
+                try:
+                    k.encode("utf-8")
+                except UnicodeEncodeError:
+                    # Mask the bad key in the path — the raw key cannot be
+                    # safely formatted into log handlers.
+                    dropped.append(f"{path}.<bad-key>" if path else "<bad-key>")
+                    continue
+            child = f"{path}.{k}" if path else str(k)
             new_v = _scrub_utf8(v, child, dropped)
             if new_v is _DROP:
                 continue
@@ -173,6 +181,13 @@ class BatchSink(ApiSink, HotglueBatchSink):
             for record in records
             if record.get("lookupKey") is not None
         ]
+        skipped = len(records) - len(ingestion_records)
+        if skipped:
+            self.logger.warning(
+                "Skipping %d %s record(s) without lookupKey (e.g. dropped during UTF-8 sanitization)",
+                skipped,
+                self.stream_name,
+            )
         request_payload = {"records": ingestion_records}
         
         endpoint = self.get_bulk_endpoint(ingestion_records[0] if ingestion_records else None)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import typing as t
 
 import pytest
@@ -12,6 +13,7 @@ try:
 except ImportError:
     get_target_test_class = None
 
+from target_api.sinks import sanitize_record_utf8
 from target_api.target import TargetApi
 
 # TODO: Initialize minimal target config
@@ -123,3 +125,65 @@ def test_drain_all_drains_active_sinks_sequentially(tmp_path, monkeypatch):
         ([], 1),
         (["accounts", "contacts"], 1),
     ]
+
+
+def test_sanitize_record_utf8_drops_only_offending_field(caplog):
+    """Non-UTF-8 fields are dropped at the leaf; sibling fields and the
+    surrounding record/structure survive. JSON-serializable result."""
+    bad = "lone-surrogate-\udce9"  # cannot encode as UTF-8
+    record = {
+        "sourceRecordId": "rec-1",
+        "lookupKey": "user@example.com",
+        "firstName": bad,
+        "data": {
+            "company": "Acme",
+            "notes": bad,
+            "tags": ["clean", bad, "also-clean"],
+        },
+    }
+
+    with caplog.at_level(logging.WARNING):
+        cleaned = sanitize_record_utf8(record, "contacts", logging.getLogger("test"))
+
+    assert cleaned == {
+        "sourceRecordId": "rec-1",
+        "lookupKey": "user@example.com",
+        "data": {
+            "company": "Acme",
+            "tags": ["clean", "also-clean"],
+        },
+    }
+    # Sanitized record must round-trip through json without errors.
+    json.dumps(cleaned).encode("utf-8")
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    msg = warnings[0].getMessage()
+    assert "firstName" in msg
+    assert "data.notes" in msg
+    assert "data.tags[1]" in msg
+    assert "rec-1" in msg
+
+
+def test_sanitize_record_utf8_passthrough_for_clean_record():
+    record = {
+        "sourceRecordId": "rec-2",
+        "lookupKey": "héllo@example.com",
+        "data": {"name": "Zoë", "tags": ["α", "β"]},
+    }
+    cleaned = sanitize_record_utf8(record, "contacts", logging.getLogger("test"))
+    assert cleaned == record
+
+
+def test_sanitize_record_utf8_drops_lookupkey_when_invalid():
+    """If the lookupKey itself is malformed, the field is dropped — the
+    existing 'no lookupKey' guard then skips the record at request time."""
+    record = {
+        "sourceRecordId": "rec-3",
+        "lookupKey": "bad-\udce9-domain.com",
+        "domain": "bad-\udce9-domain.com",
+    }
+    cleaned = sanitize_record_utf8(record, "accounts", logging.getLogger("test"))
+    assert "lookupKey" not in cleaned
+    assert "domain" not in cleaned
+    assert cleaned["sourceRecordId"] == "rec-3"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -175,6 +175,30 @@ def test_sanitize_record_utf8_passthrough_for_clean_record():
     assert cleaned == record
 
 
+def test_sanitize_record_utf8_drops_invalid_dict_keys():
+    """Lone-surrogate dict keys can't be UTF-8 encoded; the whole pair must
+    be dropped so json.dumps can't ship a malformed key to CBX1."""
+    bad_key = "key-\udce9"
+    record = {
+        "sourceRecordId": "rec-4",
+        bad_key: "outer-value",
+        "data": {
+            "good": "ok",
+            bad_key: "inner-value",
+        },
+    }
+
+    cleaned = sanitize_record_utf8(record, "contacts", logging.getLogger("test"))
+
+    assert bad_key not in cleaned
+    assert bad_key not in cleaned["data"]
+    assert cleaned == {
+        "sourceRecordId": "rec-4",
+        "data": {"good": "ok"},
+    }
+    json.dumps(cleaned).encode("utf-8")
+
+
 def test_sanitize_record_utf8_drops_lookupkey_when_invalid():
     """If the lookupKey itself is malformed, the field is dropped — the
     existing 'no lookupKey' guard then skips the record at request time."""


### PR DESCRIPTION
## Summary

Records with lone surrogates or other non-UTF-8 string values (typically from data decoded with `errors='surrogateescape'`) currently propagate through to the CBX1 bulk-upsert API and cause writes to fail.

This PR adds a recursive UTF-8 scrubber invoked from both sink paths so the offending **field** is dropped, not the whole record.

### What changed
- New `sanitize_record_utf8(record, stream_name, logger)` helper in `target_api/sinks.py`. Recursively walks dicts/lists; replaces any string that fails `.encode("utf-8")` with a sentinel and prunes it from its parent container.
- Called at the top of `RecordSink.preprocess_record` and `BatchSink.process_batch_record` so all data flowing into the request payload is clean.
- Each drop logs a single warning line with the dotted field path (e.g. `data.notes`, `data.tags[1]`) and `sourceRecordId` for traceability.

### Why this approach
- The target is the single boundary to CBX1 — applying the fix here protects every current and future tap/ETL feeding it, including the HubSpot/Salesforce `hotglue-transformation-scripts` path.
- Field-level drop preserves as much of the record as possible. If `lookupKey` itself is the corrupted field, it gets dropped and the existing "missing lookupKey" guard cleanly skips that record at request time (`sinks.py` already does this for both single and batch sinks).
- Log-on-drop gives visibility to spot upstream encoding problems without failing the run.

### Risks / rollback
- Low risk: the helper is a no-op for clean records (verified by test). Reverting is a single-commit revert.
- Behavior change: previously-failing records with one bad field will now succeed minus that field. If a downstream consumer was relying on the failure, they'll silently start receiving partial records — log warnings make this visible.

## Test plan
- [x] `test_sanitize_record_utf8_drops_only_offending_field` — bad string in top level, nested dict, and list element are all pruned; siblings and structure survive; result is JSON-serializable; warning includes the field paths and sourceRecordId.
- [x] `test_sanitize_record_utf8_passthrough_for_clean_record` — valid UTF-8 (including non-ASCII like `é`, `Zoë`, Greek letters) passes through unchanged.
- [x] `test_sanitize_record_utf8_drops_lookupkey_when_invalid` — corrupted `lookupKey` is dropped at the field level, leaving the existing missing-lookupKey guard to skip the record at the request boundary.
- [x] Existing `test_batch_sink_drains_when_full` and `test_drain_all_drains_active_sinks_sequentially` still pass.