### PR TITLE
Repair mojibake with ftfy before dropping non-UTF-8 fields

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -365,6 +365,21 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "ftfy"
+version = "6.1.1"
+description = "Fixes mojibake and other problems with Unicode, after the fact"
+optional = false
+python-versions = ">=3.7,<4"
+groups = ["main"]
+files = [
+    {file = "ftfy-6.1.1-py3-none-any.whl", hash = "sha256:0ffd33fce16b54cccaec78d6ec73d95ad370e5df5a25255c8966a6147bd667ca"},
+    {file = "ftfy-6.1.1.tar.gz", hash = "sha256:bfc2019f84fcd851419152320a6375604a0f1459c281b5b199b2cd0d2e727f8f"},
+]
+
+[package.dependencies]
+wcwidth = ">=0.2.5"
+
+[[package]]
 name = "greenlet"
 version = "2.0.2"
 description = "Lightweight in-process concurrent programming"
@@ -1110,6 +1125,18 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress ; py
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "wcwidth"
+version = "0.2.14"
+description = "Measures the displayed width of unicode strings in a terminal"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1"},
+    {file = "wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605"},
+]
+
+[[package]]
 name = "zipp"
 version = "3.15.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1132,4 +1159,4 @@ s3 = []
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.11,>=3.7.1"
-content-hash = "79057bf166b09c54e70189b62d89fef4ab044a7a9db40eae866ddee46d668330"
+content-hash = "6cc34d924217924647a69de4f259acf77274dc9f1e0ee0c2e6eadbe30f85fb3e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ python = "<3.11,>=3.7.1"
 requests = "^2.25.1"
 singer-sdk = "^0.9.0"
 target-hotglue = "^0.0.10"
+ftfy = ">=6.1,<6.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.1"

--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, List
+from typing import Any, List, Tuple
 
+import ftfy
 from target_hotglue.client import HotglueBatchSink, HotglueSink
 
 from target_api.client import ApiSink
@@ -16,42 +17,65 @@ import hashlib
 _DROP = object()
 
 
-def _scrub_utf8(value: Any, path: str, dropped: List[str]) -> Any:
-    """Recursively replace non-UTF-8 strings with the _DROP sentinel.
+def _repair_string(value: str) -> Tuple[str, bool]:
+    """Run ftfy.fix_text on a string. Returns (fixed, changed)."""
+    fixed = ftfy.fix_text(value)
+    return fixed, fixed != value
 
-    A string fails the check when it contains lone surrogates (e.g. data
-    decoded with errors='surrogateescape') and cannot be encoded as UTF-8.
-    Containers are kept; only the offending leaf is dropped.
+
+def _scrub_utf8(
+    value: Any,
+    path: str,
+    dropped: List[str],
+    repaired: List[str],
+) -> Any:
+    """Repair mojibake/lone-surrogate strings with ftfy, then drop any that
+    still cannot be UTF-8 encoded.
+
+    Mojibake (e.g. "Ã©" instead of "é") is valid UTF-8 but semantically
+    wrong; ftfy repairs it. Lone surrogates from errors='surrogateescape'
+    decoding fail .encode("utf-8") outright; ftfy.fix_text re-interprets the
+    surrogate bytes when possible. Anything still unencodable after repair
+    is dropped at the leaf — siblings survive.
     """
     if isinstance(value, str):
+        fixed, changed = _repair_string(value)
+        if changed:
+            repaired.append(path or "<root>")
         try:
-            value.encode("utf-8")
+            fixed.encode("utf-8")
         except UnicodeEncodeError:
             dropped.append(path or "<root>")
             return _DROP
-        return value
+        return fixed
     if isinstance(value, dict):
         cleaned: dict = {}
         for k, v in value.items():
+            fixed_k = k
             if isinstance(k, str):
+                fixed_k, changed = _repair_string(k)
+                if changed:
+                    repaired.append(
+                        f"{path}.<key>" if path else "<key>"
+                    )
                 try:
-                    k.encode("utf-8")
+                    fixed_k.encode("utf-8")
                 except UnicodeEncodeError:
                     # Mask the bad key in the path — the raw key cannot be
                     # safely formatted into log handlers.
                     dropped.append(f"{path}.<bad-key>" if path else "<bad-key>")
                     continue
-            child = f"{path}.{k}" if path else str(k)
-            new_v = _scrub_utf8(v, child, dropped)
+            child = f"{path}.{fixed_k}" if path else str(fixed_k)
+            new_v = _scrub_utf8(v, child, dropped, repaired)
             if new_v is _DROP:
                 continue
-            cleaned[k] = new_v
+            cleaned[fixed_k] = new_v
         return cleaned
     if isinstance(value, list):
         cleaned_list: list = []
         for i, v in enumerate(value):
             child = f"{path}[{i}]"
-            new_v = _scrub_utf8(v, child, dropped)
+            new_v = _scrub_utf8(v, child, dropped, repaired)
             if new_v is _DROP:
                 continue
             cleaned_list.append(new_v)
@@ -64,12 +88,22 @@ def sanitize_record_utf8(
     stream_name: str,
     logger: logging.Logger,
 ) -> dict:
-    """Drop fields whose string values are not valid UTF-8. Logs each drop."""
+    """Repair mojibake/lone-surrogate strings via ftfy, then drop anything
+    still unencodable as UTF-8. Logs repairs and drops separately."""
     dropped: List[str] = []
-    cleaned = _scrub_utf8(record, "", dropped)
+    repaired: List[str] = []
+    cleaned = _scrub_utf8(record, "", dropped, repaired)
+    if repaired:
+        logger.warning(
+            "Repaired %d mojibake/non-UTF-8 field(s) in %s record (sourceRecordId=%s): %s",
+            len(repaired),
+            stream_name,
+            record.get("sourceRecordId"),
+            ", ".join(repaired),
+        )
     if dropped:
         logger.warning(
-            "Dropped %d non-UTF-8 field(s) from %s record (sourceRecordId=%s): %s",
+            "Dropped %d non-UTF-8 field(s) from %s record (sourceRecordId=%s) after repair attempt: %s",
             len(dropped),
             stream_name,
             record.get("sourceRecordId"),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -127,10 +127,50 @@ def test_drain_all_drains_active_sinks_sequentially(tmp_path, monkeypatch):
     ]
 
 
-def test_sanitize_record_utf8_drops_only_offending_field(caplog):
-    """Non-UTF-8 fields are dropped at the leaf; sibling fields and the
-    surrounding record/structure survive. JSON-serializable result."""
-    bad = "lone-surrogate-\udce9"  # cannot encode as UTF-8
+def test_sanitize_record_utf8_repairs_mojibake(caplog):
+    """Mojibake — UTF-8 bytes that were decoded as latin-1 and re-encoded as
+    UTF-8 — is salvageable. ftfy reverses it, so the original name reaches
+    CBX1 instead of being silently dropped."""
+    record = {
+        "sourceRecordId": "rec-mojibake",
+        "lookupKey": "user@example.com",
+        "firstName": "CafÃ©",  # mojibake of "Café"
+        "lastName": "MÃ¼ller",  # mojibake of "Müller"
+        "data": {
+            "company": "Acme",
+            "notes": "naÃ¯ve",  # mojibake of "naïve"
+        },
+    }
+
+    with caplog.at_level(logging.WARNING):
+        cleaned = sanitize_record_utf8(record, "contacts", logging.getLogger("test"))
+
+    assert cleaned == {
+        "sourceRecordId": "rec-mojibake",
+        "lookupKey": "user@example.com",
+        "firstName": "Café",
+        "lastName": "Müller",
+        "data": {
+            "company": "Acme",
+            "notes": "naïve",
+        },
+    }
+    json.dumps(cleaned).encode("utf-8")
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    msg = warnings[0].getMessage()
+    assert "Repaired" in msg
+    assert "firstName" in msg
+    assert "lastName" in msg
+    assert "data.notes" in msg
+
+
+def test_sanitize_record_utf8_repairs_lone_surrogates(caplog):
+    """Lone surrogates (from errors='surrogateescape' decoding) get replaced
+    with U+FFFD via ftfy — the field is preserved so any remaining valid
+    context survives, instead of dropping the whole leaf."""
+    bad = "lone-surrogate-\udce9"
     record = {
         "sourceRecordId": "rec-1",
         "lookupKey": "user@example.com",
@@ -145,40 +185,54 @@ def test_sanitize_record_utf8_drops_only_offending_field(caplog):
     with caplog.at_level(logging.WARNING):
         cleaned = sanitize_record_utf8(record, "contacts", logging.getLogger("test"))
 
+    repaired_value = "lone-surrogate-�"
     assert cleaned == {
         "sourceRecordId": "rec-1",
         "lookupKey": "user@example.com",
+        "firstName": repaired_value,
         "data": {
             "company": "Acme",
-            "tags": ["clean", "also-clean"],
+            "notes": repaired_value,
+            "tags": ["clean", repaired_value, "also-clean"],
         },
     }
-    # Sanitized record must round-trip through json without errors.
     json.dumps(cleaned).encode("utf-8")
 
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert len(warnings) == 1
     msg = warnings[0].getMessage()
+    assert "Repaired" in msg
     assert "firstName" in msg
     assert "data.notes" in msg
     assert "data.tags[1]" in msg
     assert "rec-1" in msg
 
 
-def test_sanitize_record_utf8_passthrough_for_clean_record():
+def test_sanitize_record_utf8_passthrough_for_clean_record(caplog):
+    """Clean UTF-8 strings — including non-ASCII names like Zoë and the
+    intentionally weird 'X Æ A-Xii' / 'John 3rd' — pass through unchanged
+    with no log output."""
     record = {
         "sourceRecordId": "rec-2",
         "lookupKey": "héllo@example.com",
+        "firstName": "X Æ A-Xii",
+        "middleName": "John 3rd",
         "data": {"name": "Zoë", "tags": ["α", "β"]},
     }
-    cleaned = sanitize_record_utf8(record, "contacts", logging.getLogger("test"))
+    with caplog.at_level(logging.WARNING):
+        cleaned = sanitize_record_utf8(
+            record, "contacts", logging.getLogger("test")
+        )
     assert cleaned == record
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
 
 
-def test_sanitize_record_utf8_drops_invalid_dict_keys():
-    """Lone-surrogate dict keys can't be UTF-8 encoded; the whole pair must
-    be dropped so json.dumps can't ship a malformed key to CBX1."""
+def test_sanitize_record_utf8_repairs_invalid_dict_keys():
+    """Lone-surrogate dict keys are repaired (replaced with U+FFFD) so
+    json.dumps stops shipping malformed keys to CBX1 — both at the top
+    level and nested."""
     bad_key = "key-\udce9"
+    repaired_key = "key-�"
     record = {
         "sourceRecordId": "rec-4",
         bad_key: "outer-value",
@@ -194,20 +248,25 @@ def test_sanitize_record_utf8_drops_invalid_dict_keys():
     assert bad_key not in cleaned["data"]
     assert cleaned == {
         "sourceRecordId": "rec-4",
-        "data": {"good": "ok"},
+        repaired_key: "outer-value",
+        "data": {
+            "good": "ok",
+            repaired_key: "inner-value",
+        },
     }
     json.dumps(cleaned).encode("utf-8")
 
 
-def test_sanitize_record_utf8_drops_lookupkey_when_invalid():
-    """If the lookupKey itself is malformed, the field is dropped — the
-    existing 'no lookupKey' guard then skips the record at request time."""
+def test_sanitize_record_utf8_repairs_lookupkey_with_lone_surrogate():
+    """A malformed lookupKey is now repaired instead of dropped. The record
+    no longer falls through the no-lookupKey skip path; CBX1 sees a string
+    with a replacement char and can match or reject as appropriate."""
     record = {
         "sourceRecordId": "rec-3",
         "lookupKey": "bad-\udce9-domain.com",
         "domain": "bad-\udce9-domain.com",
     }
     cleaned = sanitize_record_utf8(record, "accounts", logging.getLogger("test"))
-    assert "lookupKey" not in cleaned
-    assert "domain" not in cleaned
+    assert cleaned["lookupKey"] == "bad-�-domain.com"
+    assert cleaned["domain"] == "bad-�-domain.com"
     assert cleaned["sourceRecordId"] == "rec-3"


### PR DESCRIPTION
## Summary

- `_scrub_utf8` in `target_api/sinks.py` previously dropped any string failing `.encode("utf-8")`. For CRM names this threw away salvageable data — `"CafÃ©"` is mojibake of `"Café"`, and a `\udce9` lone surrogate maps cleanly to the Unicode replacement char.
- Add `ftfy` (pinned `>=6.1,<6.2` for Python 3.7+ compat) and call `ftfy.fix_text` on every string value **and** dict key. Drop only if the repaired result is still unencodable (now effectively unreachable, kept as a defensive guard).
- Repairs and drops log separately so operators can see both classes of fix. Field-level granularity preserved — only offending leaves are touched, siblings survive.

## Behavior changes

| Input | Before | After |
|---|---|---|
| `"CafÃ©"` (mojibake of `"Café"`) | shipped as-is (garbled in CRM) | repaired to `"Café"`, warn-logged |
| `"lone-surrogate-\udce9"` | field dropped silently | repaired to `"lone-surrogate-�"`, warn-logged |
| `"X Æ A-Xii"` / `"John 3rd"` | passthrough | passthrough (unchanged) |
| Lone-surrogate dict key | key+value dropped | key repaired, pair kept |
| Lone-surrogate `lookupKey` | record skipped at request time | record kept and sent with repaired key |

## Test plan

- [x] `poetry run pytest tests/test_core.py` — 7 passed (5 sanitize tests + 2 pre-existing batch tests)
- [x] Tested mojibake repair: `"CafÃ©"` → `"Café"`, `"MÃ¼ller"` → `"Müller"`, `"naÃ¯ve"` → `"naïve"`
- [x] Tested lone-surrogate repair at value, key, and nested-list positions
- [x] Tested clean-record passthrough (`"X Æ A-Xii"`, `"John 3rd"`, `"Zoë"`, `"α"`) — no log noise
- [x] Confirmed `json.dumps(cleaned).encode("utf-8")` round-trips on every cleaned record