### PR TITLE
chore: raise default batch_size 10 → 50

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ CBX1 Bulk Upsert API (/api/t/v1/targets/{stream}/bulk)
 | Batch | `BatchSink` | `/bulk` | Yes (`process_as_batch: true`) |
 | Single | `RecordSink` | `/upsert` | No |
 
-**Batch size:** 20 records (configurable via `batch_size`)
+**Batch size:** 50 records (configurable via `batch_size`)
 
 ## Key Patterns
 
@@ -93,7 +93,7 @@ Each record in state includes:
 | Config | Description | Default |
 |--------|-------------|---------|
 | `process_as_batch` | Use batch processing | `true` |
-| `batch_size` | Records per batch | `20` |
+| `batch_size` | Records per batch | `50` |
 | `add_stream_key` | Add stream name to records | `false` |
 | `metadata` | Additional metadata to inject | `null` |
 | `inject_batch_ids` | Add batch tracking IDs | `false` |

--- a/target_api/sinks.py
+++ b/target_api/sinks.py
@@ -179,10 +179,10 @@ class BatchSink(ApiSink, HotglueBatchSink):
     @property
     def max_size(self):
         if self.config.get("process_as_batch"):
-            batch_size = self.config.get("batch_size", 10)
+            batch_size = self.config.get("batch_size", 50)
             if batch_size:
                 return int(batch_size)
-        return 10
+        return 50
 
     def process_batch_record(self, record: dict, index: int) -> dict:
         record = sanitize_record_utf8(record, self.stream_name, self.logger)


### PR DESCRIPTION
## What changed
`BatchSink.max_size` (`target_api/sinks.py`) defaulted to **10** when no `batch_size` was present in the target config. This raises the default to **50** (both the `config.get("batch_size", …)` fallback and the `process_as_batch=false` path).

Also corrects the stale `AGENTS.md` docs — they claimed the default was `20` while the code default was actually `10`. Now both read `50`. (`CLAUDE.md`/`GEMINI.md` are symlinks to `AGENTS.md`, so they update automatically.)

## Why this approach
`batch_size` is already a config knob, so the default is the only thing baked into code. Raising it to 50 reduces per-batch round-trips to the CBX1 bulk upsert API for every flow that doesn't explicitly set a size. Any flow can still override via the `batch_size` config key — behavior for flows that set it explicitly is unchanged.

## Risks / rollback
- **Risk:** larger batches mean bigger request payloads to `/bulk`. The byte-size guard in `client.py` (`max_size_in_bytes`) still bounds payloads independently, so 50 records won't exceed transport limits where that's configured. Per-record state correlation is by `lookupKey`, unaffected by batch size.
- **Rollback:** revert this commit (single 2-line code change + doc).

## Testing
`poetry run pytest` → **7 passed**. Existing tests pass `batch_size` explicitly (2 and 20), so none depended on the old default of 10.